### PR TITLE
Add enum to `language` param spec

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -10,6 +10,7 @@
             },
             "language": {
                 "type": "string",
+                "enum": ["c", "cpp", "go", "java", "javascript", "python", "ruby"],
                 "description": "A name of the programming language"
             }
         },


### PR DESCRIPTION
This should help steer LLMs away from trying to call the plugin with unsupported language identifiers.